### PR TITLE
fixed bug: features and indexes on diffent devices when using cuda.

### DIFF
--- a/model.py
+++ b/model.py
@@ -88,7 +88,7 @@ class LocalSpatialEncoding(nn.Module):
         expanded_coords = coords.transpose(-2,-1).unsqueeze(-1).expand(B, 3, N, K)
         neighbor_coords = torch.gather(expanded_coords, 2, expanded_idx) # shape (B, 3, N, K)
 
-        expanded_idx = idx.unsqueeze(1).expand(B, features.size(1), N, K)
+        expanded_idx = idx.unsqueeze(1).expand(B, features.size(1), N, K).to(self.device)
         expanded_features = features.expand(B, -1, N, K)
         neighbor_features = torch.gather(expanded_features, 2, expanded_idx)
         # if USE_CUDA:


### PR DESCRIPTION
Hi there.

Using CUDA version of local spatial encoding in the 'gather' branch  (#17) will get the following error:

> RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking arugment for argument index in method wrapper_gather)

This can be fixed by moving indexes (expanded_idx) to the same device of features.